### PR TITLE
Use batch ID for generating unaddressed QID Pairs

### DIFF
--- a/app/generate_qid_batch.py
+++ b/app/generate_qid_batch.py
@@ -1,21 +1,22 @@
 import csv
 import json
+import uuid
 
 from flask import current_app
 
 from app.rabbit_context import RabbitContext
 
 
-def generate_messages_from_config_file(config_file):
-    config_file_reader = csv.DictReader(config_file, delimiter=',')
+def generate_messages_from_config_file(config_file, batch_id: uuid.UUID):
+    config_file_reader = csv.DictReader(config_file)
     with RabbitContext(queue_name=current_app.config['RABBITMQ_UNADDRESSED_QID_QUEUE']) as rabbit:
         for row in config_file_reader:
             message_count = int(row['Quantity'])
-            message_json = create_message_json(row['Questionnaire type'])
+            message_json = create_message_json(row['Questionnaire type'], batch_id)
             print(f'Queueing {message_count} questionnaire type {row["Questionnaire type"]}')
             for _ in range(message_count):
                 rabbit.publish_message(message_json, 'application/json')
 
 
-def create_message_json(questionnaire_type):
-    return json.dumps({'questionnaireType': questionnaire_type})
+def create_message_json(questionnaire_type, batch_id: uuid.UUID):
+    return json.dumps({'questionnaireType': questionnaire_type, 'batchId': str(batch_id)})

--- a/app/templates/generate_qid_batch.html
+++ b/app/templates/generate_qid_batch.html
@@ -7,6 +7,11 @@
         <h1>Upload a QID batch config file</h1>
         <p>Upload a CSV config file specifying the questionnaire type and quantities of unaddressed QID/UAC pairs to generate</p>
         <form enctype="multipart/form-data">
+            <div class="form-group col-4">
+                <label for="action_rule_id">Batch ID</label>
+                <input class="form-control" type="text" id="batch_id" name="batch_id"
+                       placeholder="Leave blank to generate">
+            </div>
             <div class="input-group mb-3">
                 <div class="custom-file">
                     <input type="file" id="config-file-upload" name="config-file">

--- a/app/views/action_rules.py
+++ b/app/views/action_rules.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from flask import Blueprint, render_template, url_for, request, Response
+from flask import Blueprint, render_template, url_for, request
 from werkzeug.exceptions import abort
 from werkzeug.utils import redirect
 
@@ -30,13 +30,13 @@ def create_action_rule(action_plan_id):
     try:
         trigger_date_time = convert_to_iso_timestamp(request.form['trigger_date_time'])
     except ValueError:
-        abort(400)
+        abort(400, 'Invalid trigger date time')
 
     if request.form.get('classifiers'):
         try:
             classifiers = json.loads(request.form['classifiers'])
         except ValueError:
-            abort(Response('Invalid classifiers json', 400))
+            abort(400, 'Invalid classifiers json')
     else:
         classifiers = None
 

--- a/app/views/generate_qid_batch.py
+++ b/app/views/generate_qid_batch.py
@@ -1,3 +1,5 @@
+import uuid
+
 from flask import Blueprint, render_template, request, url_for
 from werkzeug.exceptions import abort
 from werkzeug.utils import redirect
@@ -18,11 +20,15 @@ def get_generate_qid_batch():
 @auth.login_required
 def generate_qid_batch():
     if 'config-file' not in request.files:
-        abort(400)
+        abort(400, 'No config file selected')
 
+    try:
+        batch_id = uuid.UUID(request.form['batch_id'], version=4) if request.form['batch_id'] else uuid.uuid4()
+    except ValueError:
+        abort(400, 'Invalid batch ID UUID')
     batch_config_file_bytes = request.files['config-file'].stream
     batch_config_file = (line.decode() for line in batch_config_file_bytes)
 
-    generate_messages_from_config_file(batch_config_file)
+    generate_messages_from_config_file(batch_config_file, batch_id)
 
     return redirect(url_for('action_plans.get_action_plans'))

--- a/app/views/generate_qid_batch.py
+++ b/app/views/generate_qid_batch.py
@@ -25,7 +25,7 @@ def generate_qid_batch():
     try:
         batch_id = uuid.UUID(request.form['batch_id'], version=4) if request.form['batch_id'] else uuid.uuid4()
     except ValueError:
-        abort(400, 'Invalid batch ID UUID')
+        abort(400, 'Invalid UUID for batch ID')
     batch_config_file_bytes = request.files['config-file'].stream
     batch_config_file = (line.decode() for line in batch_config_file_bytes)
 

--- a/app/views/load_sample.py
+++ b/app/views/load_sample.py
@@ -19,7 +19,7 @@ def get_sample(action_plan_id):
 @auth.login_required
 def upload_sample(action_plan_id):
     if 'sample' not in request.files:
-        abort(400)
+        abort(400, 'No sample file selected')
 
     sample_file_in_bytes = request.files['sample'].stream
     sample_file = (line.decode() for line in sample_file_in_bytes)

--- a/tests/test_generate_qid_batch.py
+++ b/tests/test_generate_qid_batch.py
@@ -1,26 +1,51 @@
 import json
+import uuid
 from unittest.mock import patch
+
+import pytest
 
 from app import create_app
 from app.generate_qid_batch import generate_messages_from_config_file
 
 
-def test_generate_messages_from_config_file_path():
-    # Given
+@pytest.fixture(autouse=True)
+def use_unit_test_config():
     app = create_app('UnitTestConfig')
     app.app_context().push()
-    config_file = ('"Questionnaire type","Quantity"\n',
-                   '"01","2"\n',
-                   '"02","1"')
+
+
+def test_generate_messages_from_config_file_path_publishes_correct_quantities():
+    # Given
+    batch_id = uuid.uuid4()
 
     # When
-    with patch('app.generate_qid_batch.RabbitContext') as patch_rabbit:
-        generate_messages_from_config_file(config_file)
+    publish_message_call_list = generate_messages_with_mocked_rabbit(('"Questionnaire type","Quantity"\n',
+                                                                      '"01","2"\n',
+                                                                      '"02","1"'),
+                                                                     batch_id)
 
     # Then
-    patch_rabbit_context = patch_rabbit.return_value.__enter__.return_value
-    publish_message_call_list = patch_rabbit_context.publish_message.call_args_list
-
     assert json.loads(publish_message_call_list[0][0][0])['questionnaireType'] == '01'
     assert json.loads(publish_message_call_list[1][0][0])['questionnaireType'] == '01'
     assert json.loads(publish_message_call_list[2][0][0])['questionnaireType'] == '02'
+    assert len(publish_message_call_list) == 3
+
+
+def test_generate_messages_from_config_file_path_sets_batch_id():
+    # Given
+    batch_id = uuid.uuid4()
+
+    # When
+    publish_message_call_list = generate_messages_with_mocked_rabbit(('"Questionnaire type","Quantity"\n',
+                                                                      '"01","2"\n',
+                                                                      '"02","1"'),
+                                                                     batch_id)
+
+    # Then
+    assert all(json.loads(message[0][0])['batchId'] == str(batch_id) for message in publish_message_call_list)
+
+
+def generate_messages_with_mocked_rabbit(config_file, batch_id):
+    with patch('app.generate_qid_batch.RabbitContext') as patch_rabbit:
+        generate_messages_from_config_file(config_file, batch_id)
+    return patch_rabbit.return_value.__enter__.return_value.publish_message.call_args_list

--- a/tests/views/test_generate_qid_batch.py
+++ b/tests/views/test_generate_qid_batch.py
@@ -1,8 +1,9 @@
+import uuid
 from io import BytesIO
 from unittest.mock import patch
 
 
-def test_get_upload_sample_page(client):
+def test_get_upload_generate_qid_batch_page(client):
     response = client.get('/generate-qid-batch')
 
     assert response.status_code == 200
@@ -10,12 +11,59 @@ def test_get_upload_sample_page(client):
 
 
 def test_upload_qid_batch_config_file_empty_batch_id(client):
-    with patch('app.views.generate_qid_batch.generate_messages_from_config_file') \
-            as generate_messages_from_config_file_patch:
-        response = client.post('/generate-qid-batch',
-                               data={'config-file': (BytesIO(b'header\nline'), 'config-file.csv'),
-                                     'batch_id': ''})
+    # Given
+    post_data = {'config-file': (BytesIO(b'config\nfile'), 'config-file.csv'), 'batch_id': ''}
 
+    # When
+    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+
+    # Then
     generate_messages_from_config_file_patch.assert_called_once()
-
     assert response.status_code == 302
+    call_batch_id = generate_messages_from_config_file_patch.call_args[0][1]
+    assert isinstance(call_batch_id, uuid.UUID)
+
+
+def test_upload_qid_batch_config_file_with_batch_id(client):
+    # Given
+    batch_id = uuid.uuid4()
+    post_data = {'config-file': (BytesIO(b'config\nfile'), 'config-file.csv'), 'batch_id': batch_id}
+
+    # When
+    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+
+    # Then
+    generate_messages_from_config_file_patch.assert_called_once()
+    assert response.status_code == 302
+    call_batch_id = generate_messages_from_config_file_patch.call_args[0][1]
+    assert call_batch_id == batch_id
+
+
+def test_upload_qid_batch_config_file_invalid_batch_id(client):
+    # Given
+    post_data = {'config-file': (BytesIO(b'config\nfile'), 'config-file.csv'), 'batch_id': 'not_a_valid_uuid4'}
+
+    # When
+    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+
+    # Then
+    assert response.status_code == 400
+    assert b'Invalid UUID for batch ID' in response.data
+
+
+def test_upload_qid_batch_no_config_file(client):
+    # Given
+    post_data = {'batch_id': ''}
+
+    # When
+    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+
+    # Then
+    assert response.status_code == 400
+    assert b'No config file selected' in response.data
+
+
+def post_to_generate_qid_batch(client, data):
+    with patch('app.views.generate_qid_batch.generate_messages_from_config_file') as patched_generate:
+        response = client.post('/generate-qid-batch', data=data)
+    return patched_generate, response

--- a/tests/views/test_generate_qid_batch.py
+++ b/tests/views/test_generate_qid_batch.py
@@ -15,12 +15,12 @@ def test_upload_qid_batch_config_file_empty_batch_id(client):
     post_data = {'config-file': (BytesIO(b'config\nfile'), 'config-file.csv'), 'batch_id': ''}
 
     # When
-    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+    patched_generate_batch, response = post_to_generate_qid_batch(client, post_data)
 
     # Then
-    generate_messages_from_config_file_patch.assert_called_once()
+    patched_generate_batch.assert_called_once()
     assert response.status_code == 302
-    call_batch_id = generate_messages_from_config_file_patch.call_args[0][1]
+    call_batch_id = patched_generate_batch.call_args[0][1]
     assert isinstance(call_batch_id, uuid.UUID)
 
 
@@ -30,12 +30,12 @@ def test_upload_qid_batch_config_file_with_batch_id(client):
     post_data = {'config-file': (BytesIO(b'config\nfile'), 'config-file.csv'), 'batch_id': batch_id}
 
     # When
-    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+    patched_generate_batch, response = post_to_generate_qid_batch(client, post_data)
 
     # Then
-    generate_messages_from_config_file_patch.assert_called_once()
+    patched_generate_batch.assert_called_once()
     assert response.status_code == 302
-    call_batch_id = generate_messages_from_config_file_patch.call_args[0][1]
+    call_batch_id = patched_generate_batch.call_args[0][1]
     assert call_batch_id == batch_id
 
 
@@ -44,7 +44,7 @@ def test_upload_qid_batch_config_file_invalid_batch_id(client):
     post_data = {'config-file': (BytesIO(b'config\nfile'), 'config-file.csv'), 'batch_id': 'not_a_valid_uuid4'}
 
     # When
-    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+    _, response = post_to_generate_qid_batch(client, post_data)
 
     # Then
     assert response.status_code == 400
@@ -56,7 +56,7 @@ def test_upload_qid_batch_no_config_file(client):
     post_data = {'batch_id': ''}
 
     # When
-    generate_messages_from_config_file_patch, response = post_to_generate_qid_batch(client, post_data)
+    _, response = post_to_generate_qid_batch(client, post_data)
 
     # Then
     assert response.status_code == 400
@@ -64,6 +64,6 @@ def test_upload_qid_batch_no_config_file(client):
 
 
 def post_to_generate_qid_batch(client, data):
-    with patch('app.views.generate_qid_batch.generate_messages_from_config_file') as patched_generate:
+    with patch('app.views.generate_qid_batch.generate_messages_from_config_file') as patched_generate_batch:
         response = client.post('/generate-qid-batch', data=data)
-    return patched_generate, response
+    return patched_generate_batch, response

--- a/tests/views/test_generate_qid_batch.py
+++ b/tests/views/test_generate_qid_batch.py
@@ -9,11 +9,12 @@ def test_get_upload_sample_page(client):
     assert b'Upload a QID batch config file' in response.data
 
 
-def test_upload_qid_batch_config_file(client):
+def test_upload_qid_batch_config_file_empty_batch_id(client):
     with patch('app.views.generate_qid_batch.generate_messages_from_config_file') \
             as generate_messages_from_config_file_patch:
         response = client.post('/generate-qid-batch',
-                               data={'config-file': (BytesIO(b'header\nline'), 'config-file.csv')})
+                               data={'config-file': (BytesIO(b'header\nline'), 'config-file.csv'),
+                                     'batch_id': ''})
 
     generate_messages_from_config_file_patch.assert_called_once()
 


### PR DESCRIPTION
 Motivation and Context
We need to be able to identify batches of unaddressed uac qid pairs, the easiest solution for this was to add in a UUID batch_id column which is set off the unaddressed request messages.

# What has changed
- Add a batch ID text box to the UI or generate one if left empty
- Pass the batch ID into the unaddressed qid request messages 
- Copy across generate qid batch changes from qid-batch-runner branch

# How to test?
Build and run the linked case-processor branch, try generating multiple batches from the ops UI. It should pass a valid UUID in if it is given one, or generate one if not.

# Links
https://github.com/ONSdigital/census-rm-case-processor/pull/18
https://github.com/ONSdigital/census-rm-case-api/pull/6
https://github.com/ONSdigital/census-rm-qid-batch-runner/pull/3
https://trello.com/c/sOyLOxiP/783-add-batch-identifier-to-unaddressed-qid-uac-pairs-5