### PR TITLE
Fix docker build issue from #11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+tests
+.env
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ ENV APP_SETTINGS=K8SDevelopmentConfig
 WORKDIR /app
 COPY . /app
 EXPOSE 8003
-RUN apt-get update -y && apt-get install -y python-pip && apt-get install -y curl
+RUN apt-get update -y && apt-get install -y python-pip curl git
 RUN pip3 install pipenv && pipenv install --deploy --system
+RUN apt-get remove -y --purge git
 
 ENTRYPOINT ["python3"]
 CMD ["run.py"]


### PR DESCRIPTION
# Motivation and Context
https://github.com/ONSdigital/census-rm-ops/pull/11 Broke the docker build as it now requires git to run the pipenv install.

# What has changed
* Install git in docker build then purge it after installing
* Add dockerignore

# How to test?
Run `make docker`

# Links
https://trello.com/c/GgRSVlOY/795-importing-python-modules-from-github-repos-1-hour
https://github.com/ONSdigital/census-rm-ops/pull/11