### PR TITLE
Remove docker push from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   global:
     - APP_SETTINGS=DevConfig
     - PIPENV_IGNORE_VIRTUALENVS=1
-    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-ops"
 
 install:
   - pip install pipenv
@@ -16,14 +15,9 @@ install:
 
 script:
   - pipenv check
-  - make test
+  - make docker
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    docker build -t "$DESTINATION_IMAGE_NAME" .;
-    docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-    docker push "$DESTINATION_IMAGE_NAME";
-    fi
   - pipenv run codecov
 
 branches:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Concourse will now handle the building and pushing of our Docker services to GCR.

## What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added fail on docker build to script section of Travis file
