### PR TITLE
RMC-157 Add reminder action types to action rules selection

### DIFF
--- a/app/views/action_rules.py
+++ b/app/views/action_rules.py
@@ -18,7 +18,17 @@ ACTION_TYPES = {
     "ICHHQE",
     "ICHHQW",
     "ICHHQN",
-    "FF2QE"
+    "FF2QE",
+    "P_RL_1RL1_1",
+    "P_RL_1RL2B_1",
+    "P_RL_1RL4",
+    "P_RL_1RL1_2",
+    "P_RL_1RL2B_2",
+    "P_RL_2RL1_3a",
+    "P_RL_2RL2B_3a",
+    "P_QU_H1",
+    "P_QU_H2",
+    "P_QU_H4",
 }
 
 


### PR DESCRIPTION
# Motivation and Context
We have added these action types for scheduled reminders, ops tool needs them in it's action type set to be able to schedule them

# What has changed
* Add reminder action types to set

# How to test?
Run with linked branches, you should be able to schedule reminder action rules from the ops tool.

# Links
https://trello.com/c/4GUC0HS0/723-rmc-157-schedule-generate-and-distribute-reminder-pqs-5
https://github.com/ONSdigital/census-rm-action-scheduler/pull/32
https://github.com/ONSdigital/census-rm-print-file-service/pull/13
