### PR TITLE
Increase number of action plans from 20 to 1000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pipenv install --dev --deploy
 
 script:
-  - pipenv check
+  - PIPENV_PYUP_API_KEY="" pipenv check
   - make docker
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 
 lint:
 	pipenv run flake8 ./app ./tests
-	pipenv check ./app ./tests
+	PIPENV_PYUP_API_KEY="" pipenv check ./app ./tests
 
 test: lint
 	pipenv run pytest --cov-report term-missing --cov app --capture no

--- a/app/controllers/action_controller.py
+++ b/app/controllers/action_controller.py
@@ -13,7 +13,7 @@ def create_action_rule(action_rule_id, trigger_date_time, classifiers, action_pl
 
 
 def get_action_plans():
-    response = requests.get(f"{app.config['ACTION_SERVICE']}/actionPlans")
+    response = requests.get(f"{app.config['ACTION_SERVICE']}/actionPlans?size=1000")
     response.raise_for_status()
     action_plans = [{'id': action_plan['_links']['self']['href'].split('/')[-1],
                      'name': action_plan['name'],
@@ -42,7 +42,7 @@ def create_action_plan(action_plan):
 
 
 def get_action_rules(action_plan_id):
-    response = requests.get(f"{app.config['ACTION_SERVICE']}/actionPlans/{action_plan_id}/actionRules")
+    response = requests.get(f"{app.config['ACTION_SERVICE']}/actionPlans/{action_plan_id}/actionRules?size=1000")
     response.raise_for_status()
     return [{'id': action_rule['_links']['self']['href'].split('/')[-1],
              'trigger_date_time': action_rule['triggerDateTime'],


### PR DESCRIPTION
# Motivation and Context
The ops tool only displays the first 20 action plans and action rules.

# What has changed
Increased limit to 1,000.

# How to test?
Create more that 20 action plans and see if you can see them using the ops tool.

# Links
Trello: https://trello.com/c/wMo6KtBl