### PR TITLE
1023 Use SQL classifiers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM python:3.7-slim
 
 ENV APP_SETTINGS=K8SDevelopmentConfig
 
-WORKDIR /app
-COPY . /app
-EXPOSE 8003
-RUN apt-get update -y && apt-get install -y python-pip curl git
-RUN pip3 install pipenv && pipenv install --deploy --system
+RUN pip install pipenv
+RUN apt-get update -y && apt-get install -y curl git
+
+WORKDIR /home/ops-tool
+CMD ["python3", "run.py"]
+
+COPY Pipfile* /home/ops-tool/
+RUN pipenv install --deploy --system
 RUN apt-get remove -y --purge git
 
-ENTRYPOINT ["python3"]
-CMD ["run.py"]
+COPY . /home/ops-tool
+EXPOSE 8003

--- a/app/controllers/action_controller.py
+++ b/app/controllers/action_controller.py
@@ -2,9 +2,9 @@ import requests
 from flask import current_app as app
 
 
-def create_action_rule(action_rule_id, trigger_date_time, classifiers, action_plan_url, action_type,
+def create_action_rule(action_rule_id, trigger_date_time, where_clause, action_plan_url, action_type,
                        has_triggered=False):
-    body = {'id': action_rule_id, 'triggerDateTime': trigger_date_time, 'classifiers': classifiers,
+    body = {'id': action_rule_id, 'triggerDateTime': trigger_date_time, 'userDefinedWhereClause': where_clause,
             'actionPlan': action_plan_url, 'actionType': action_type, 'hasTriggered': has_triggered}
     response = requests.post(f'{app.config["ACTION_SERVICE"]}/actionRules', json=body)
     response.raise_for_status()
@@ -47,6 +47,6 @@ def get_action_rules(action_plan_id):
     return [{'id': action_rule['_links']['self']['href'].split('/')[-1],
              'trigger_date_time': action_rule['triggerDateTime'],
              'action_type': action_rule['actionType'],
-             'classifiers': action_rule['classifiers'],
+             'where_clause': action_rule['userDefinedWhereClause'],
              'has_triggered': action_rule['hasTriggered']}
             for action_rule in response.json()['_embedded']['actionRules']]

--- a/app/controllers/action_controller.py
+++ b/app/controllers/action_controller.py
@@ -2,9 +2,9 @@ import requests
 from flask import current_app as app
 
 
-def create_action_rule(action_rule_id, trigger_date_time, where_clause, action_plan_url, action_type,
+def create_action_rule(action_rule_id, trigger_date_time, classifiers_clause, action_plan_url, action_type,
                        has_triggered=False):
-    body = {'id': action_rule_id, 'triggerDateTime': trigger_date_time, 'userDefinedWhereClause': where_clause,
+    body = {'id': action_rule_id, 'triggerDateTime': trigger_date_time, 'classifiersClause': classifiers_clause,
             'actionPlan': action_plan_url, 'actionType': action_type, 'hasTriggered': has_triggered}
     response = requests.post(f'{app.config["ACTION_SERVICE"]}/actionRules', json=body)
     response.raise_for_status()
@@ -47,6 +47,6 @@ def get_action_rules(action_plan_id):
     return [{'id': action_rule['_links']['self']['href'].split('/')[-1],
              'trigger_date_time': action_rule['triggerDateTime'],
              'action_type': action_rule['actionType'],
-             'where_clause': action_rule['userDefinedWhereClause'],
+             'classifiers_clause': action_rule['classifiersClause'],
              'has_triggered': action_rule['hasTriggered']}
             for action_rule in response.json()['_embedded']['actionRules']]

--- a/app/templates/action_rules.html
+++ b/app/templates/action_rules.html
@@ -35,8 +35,12 @@
             <div class="form-group">
                 <label for="action_type">Action type</label>
                 <select class="form-control" id="action_type" name="action_type">
-                    {% for item in action_types %}
-                        <option value="{{ item }}">{{ item }}</option>
+                    {% for group_name, group in action_types.items() %}
+                        <optgroup label="{{ group_name }}">
+                        {% for action_type in group %}
+                            <option value="{{ action_type }}">{{ action_type }}</option>
+                        {% endfor %}
+                        </optgroup>
                     {% endfor %}
                 </select>
             </div>
@@ -46,7 +50,8 @@
             </div>
             <div class="form-group">
                 <label for="where_clause">Where clause</label>
-                <textarea class="form-control" id="where_clause" name="where_clause" rows="5">case_type != 'HI' AND </textarea>
+                <textarea class="form-control" id="where_clause" name="where_clause"
+                          rows="5">case_type != 'HI' AND </textarea>
             </div>
             <div class="form-group">
                 <input class="form-control" type="submit" formmethod="post" value="Create">

--- a/app/templates/action_rules.html
+++ b/app/templates/action_rules.html
@@ -46,7 +46,7 @@
             </div>
             <div class="form-group">
                 <label for="where_clause">Where clause</label>
-                <textarea class="form-control" id="where_clause" name="where_clause" rows="5"></textarea>
+                <textarea class="form-control" id="where_clause" name="where_clause" rows="5">case_type != 'HI' AND </textarea>
             </div>
             <div class="form-group">
                 <input class="form-control" type="submit" formmethod="post" value="Create">

--- a/app/templates/action_rules.html
+++ b/app/templates/action_rules.html
@@ -17,7 +17,7 @@
                         <label class="tab"><b>Trigger date time:</b> {{ action_rule.trigger_date_time }}</label>
                     </div>
                     <div class="row">
-                        <label class="tab"><b>Classifiers:</b> {{ action_rule.classifiers }}</label>
+                        <label class="tab"><b>Where clause:</b> {{ action_rule.where_clause }}</label>
                     </div>
                     <div class="row">
                         <label class="tab"><b>Has triggered:</b> {{ action_rule.has_triggered }}</label>
@@ -45,8 +45,8 @@
                 <input class="form-control" type="datetime-local" id="trigger_date_time" name="trigger_date_time">
             </div>
             <div class="form-group">
-                <label for="classifiers">Classifiers JSON</label>
-                <textarea class="form-control" id="classifiers" name="classifiers" rows="5"></textarea>
+                <label for="where_clause">Where clause</label>
+                <textarea class="form-control" id="where_clause" name="where_clause" rows="5"></textarea>
             </div>
             <div class="form-group">
                 <input class="form-control" type="submit" formmethod="post" value="Create">

--- a/app/templates/action_rules.html
+++ b/app/templates/action_rules.html
@@ -17,7 +17,7 @@
                         <label class="tab"><b>Trigger date time:</b> {{ action_rule.trigger_date_time }}</label>
                     </div>
                     <div class="row">
-                        <label class="tab"><b>Where clause:</b> {{ action_rule.where_clause }}</label>
+                        <label class="tab"><b>Classifiers clause:</b> {{ action_rule.classifiers_clause }}</label>
                     </div>
                     <div class="row">
                         <label class="tab"><b>Has triggered:</b> {{ action_rule.has_triggered }}</label>
@@ -49,8 +49,8 @@
                 <input class="form-control" type="datetime-local" id="trigger_date_time" name="trigger_date_time">
             </div>
             <div class="form-group">
-                <label for="where_clause">Where clause</label>
-                <textarea class="form-control" id="where_clause" name="where_clause"
+                <label for="classifiers_clause">Classifiers clause</label>
+                <textarea class="form-control" id="classifiers_clause" name="classifiers_clause"
                           rows="5">case_type != 'HI' AND </textarea>
             </div>
             <div class="form-group">

--- a/app/views/action_rules.py
+++ b/app/views/action_rules.py
@@ -104,19 +104,19 @@ def create_action_rule(action_plan_id):
     except ValueError:
         abort(400, 'Invalid trigger date time')
 
-    if not request.form.get('where_clause') or not request.form.get('where_clause').strip():
-        abort(400, 'Empty where clause')
+    if not request.form.get('classifiers_clause') or not request.form.get('classifiers_clause').strip():
+        abort(400, 'Empty classifiers clause')
 
-    if request.form.get('where_clause').strip().endswith('AND'):
-        abort(400, 'Invalid where clause')
+    if request.form.get('classifiers_clause').strip().endswith('AND'):
+        abort(400, 'Invalid classifiers clause')
 
-    where_clause = request.form['where_clause']
+    classifiers_clause = request.form['classifiers_clause']
 
     action_plan = action_controller.get_action_plan(action_plan_id)
 
     action_controller.create_action_rule(action_rule_id=request.form.get('action_rule_id') or str(uuid.uuid4()),
                                          trigger_date_time=trigger_date_time,
-                                         where_clause=where_clause,
+                                         classifiers_clause=classifiers_clause,
                                          action_plan_url=action_plan['url'],
                                          action_type=request.form['action_type'])
     return redirect(url_for('action_rules.get_action_rules', action_plan_id=action_plan_id))

--- a/app/views/action_rules.py
+++ b/app/views/action_rules.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 
 from flask import Blueprint, render_template, url_for, request
@@ -83,19 +82,16 @@ def create_action_rule(action_plan_id):
     except ValueError:
         abort(400, 'Invalid trigger date time')
 
-    if request.form.get('classifiers'):
-        try:
-            classifiers = json.loads(request.form['classifiers'])
-        except ValueError:
-            abort(400, 'Invalid classifiers json')
+    if request.form.get('where_clause'):
+        where_clause = request.form['where_clause']
     else:
-        classifiers = None
+        where_clause = None
 
     action_plan = action_controller.get_action_plan(action_plan_id)
 
     action_controller.create_action_rule(action_rule_id=request.form.get('action_rule_id') or str(uuid.uuid4()),
                                          trigger_date_time=trigger_date_time,
-                                         classifiers=classifiers,
+                                         where_clause=where_clause,
                                          action_plan_url=action_plan['url'],
                                          action_type=request.form['action_type'])
     return redirect(url_for('action_rules.get_action_rules', action_plan_id=action_plan_id))

--- a/app/views/action_rules.py
+++ b/app/views/action_rules.py
@@ -82,10 +82,13 @@ def create_action_rule(action_plan_id):
     except ValueError:
         abort(400, 'Invalid trigger date time')
 
-    if request.form.get('where_clause'):
-        where_clause = request.form['where_clause']
-    else:
-        where_clause = None
+    if not request.form.get('where_clause') or not request.form.get('where_clause').strip():
+        abort(400, 'Empty where clause')
+
+    if request.form.get('where_clause').strip().endswith('AND'):
+        abort(400, 'Invalid where clause')
+
+    where_clause = request.form['where_clause']
 
     action_plan = action_controller.get_action_plan(action_plan_id)
 

--- a/app/views/action_rules.py
+++ b/app/views/action_rules.py
@@ -11,58 +11,80 @@ from app.timestamp import convert_to_iso_timestamp
 blueprint = Blueprint('action_rules', __name__, template_folder='templates')
 
 ACTION_TYPES = {
-    "FIELD",
+    'Field': ["FIELD"],
+    'Initial contact letters HH': [
+        "ICL1E",
+        "ICL2W",
+        "ICL4N",
+    ],
 
-    "ICL1E",
-    "ICL2W",
-    "ICL4N",
+    'Initial contact letter CE1': [
+        "CE1_IC01",
+        "CE1_IC02",
+    ],
+    'Initial contact letter CE Estab Individual': [
+        "CE_IC03",
+        "CE_IC04",
+    ],
+    'Initial contact letter CE Unit Individual': [
+        "CE_IC03_1",
+        "CE_IC04_1",
+    ],
+    'Initial contact letter CE Individual (NI)': [
+        "CE_IC05",
+        "CE_IC06",
+    ],
+    'Initial contact letter SPG': [
+        "SPG_IC11",
+        "SPG_IC12",
+    ],
+    "Initial contact q'naires HH": [
+        "ICHHQE",
+        "ICHHQW",
+        "ICHHQN",
+    ],
+    "Initial contact q'naires CE Individual": [
+        "CE_IC08",
+        "CE_IC09",
+        "CE_IC10",
+    ],
+    "Initial contact q'naires SPG": [
+        "SPG_IC13",
+        "SPG_IC14",
+    ],
 
-    "ICHHQE",
-    "ICHHQW",
-    "ICHHQN",
+    'Reminder letters': [
+        "P_RL_1RL1_1",
+        "P_RL_1RL2B_1",
+        "P_RL_1RL4",
+        "P_RL_1RL1_2",
+        "P_RL_1RL2B_2",
+        "P_RL_2RL1_3a",
+        "P_RL_2RL2B_3a",
+    ],
+    'Reminder letters, response driven': [
 
-    "P_RL_1RL1_1",
-    "P_RL_1RL2B_1",
-    "P_RL_1RL4",
-    "P_RL_1RL1_2",
-    "P_RL_1RL2B_2",
-    "P_RL_2RL1_3a",
-    "P_RL_2RL2B_3a",
+        "P_RD_2RL1_1",
+        "P_RD_2RL2B_1",
+        "P_RD_2RL1_2",
+        "P_RD_2RL2B_2",
+        "P_RD_2RL1_3",
+        "P_RD_2RL2B_3",
+    ],
+    'Reminder letters, survey launched': [
+        "P_RL_1RL1A",
+        "P_RL_1RL2BA",
+        "P_RL_2RL1A",
+        "P_RL_2RL2BA",
 
-    "P_RL_1RL1A",
-    "P_RL_1RL2BA",
-    "P_RL_2RL1A",
-    "P_RL_2RL2BA",
+    ],
 
-    "P_RD_2RL1_1",
-    "P_RD_2RL2B_1",
-    "P_RD_2RL1_2",
-    "P_RD_2RL2B_2",
-    "P_RD_2RL1_3",
-    "P_RD_2RL2B_3",
+    "Reminder q'naires": [
+        "P_QU_H1",
+        "P_QU_H2",
+        "P_QU_H4",
+    ],
 
-    "P_QU_H1",
-    "P_QU_H2",
-    "P_QU_H4",
-
-    "CE1_IC01",
-    "CE1_IC02",
-
-    "CE_IC03",
-    "CE_IC04",
-    "CE_IC05",
-    "CE_IC06",
-    "CE_IC08",
-    "CE_IC09",
-    "CE_IC10",
-
-    "CE_IC03_1",
-    "CE_IC04_1",
-
-    "SPG_IC11",
-    "SPG_IC12",
-    "SPG_IC13",
-    "SPG_IC14",
 }
 
 

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -19,7 +19,7 @@ ACTION_RULES = {
             "actionType": "ICL1E",
             "triggerDateTime": "2019-05-08T08:00:00Z",
             "hasTriggered": False,
-            "classifiers": None,
+            "userDefinedWhereClause": None,
             "_links": {
                 "self": {
                     "href": "http://localhost:8301/actionRules/156ba07d-37eb-4836-a1fb-3ab1580c1cf9"

--- a/tests/views/__init__.py
+++ b/tests/views/__init__.py
@@ -19,7 +19,7 @@ ACTION_RULES = {
             "actionType": "ICL1E",
             "triggerDateTime": "2019-05-08T08:00:00Z",
             "hasTriggered": False,
-            "userDefinedWhereClause": None,
+            "classifiersClause": None,
             "_links": {
                 "self": {
                     "href": "http://localhost:8301/actionRules/156ba07d-37eb-4836-a1fb-3ab1580c1cf9"

--- a/tests/views/test_action_rules.py
+++ b/tests/views/test_action_rules.py
@@ -2,8 +2,7 @@ from tests.views import ACTION_PLAN, ACTION_RULES
 
 
 def test_get_action_rules(client, requests_mock):
-    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0', json=ACTION_PLAN)
-    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/actionRules', json=ACTION_RULES)
+    mock_gets_from_action_scheduler(requests_mock)
 
     response = client.get('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules')
 
@@ -14,12 +13,63 @@ def test_get_action_rules(client, requests_mock):
 
 
 def test_create_action_rule(client, requests_mock):
-    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0', json=ACTION_PLAN)
-    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/actionRules', json=ACTION_RULES)
-    requests_mock.post('/actionRules', json={})
+    mock_gets_from_action_scheduler(requests_mock)
+    mock_post_to_action_scheduler(requests_mock)
+
+    response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
+        'trigger_date_time': '2019-05-08T09:00',
+        'action_type': 'ICL1E',
+        'where_clause': "case_type != 'HI'"
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+
+
+def test_invalid_classifiers_responds_400(client, requests_mock):
+    mock_gets_from_action_scheduler(requests_mock)
+    mock_post_to_action_scheduler(requests_mock)
+
+    response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
+        'trigger_date_time': '2019-05-08T09:00',
+        'action_type': 'ICL1E',
+        'where_clause': "case_type != 'HI' AND "
+    }, follow_redirects=True)
+
+    assert response.status_code == 400
+    assert b'Invalid where clause' in response.data
+
+
+def test_missing_classifiers_responds_400(client, requests_mock):
+    mock_gets_from_action_scheduler(requests_mock)
+    mock_post_to_action_scheduler(requests_mock)
+
     response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
         'trigger_date_time': '2019-05-08T09:00',
         'action_type': 'ICL1E',
     }, follow_redirects=True)
 
-    assert response.status_code == 200
+    assert response.status_code == 400
+    assert b'Empty where clause' in response.data
+
+
+def test_empty_classifiers_responds_400(client, requests_mock):
+    mock_gets_from_action_scheduler(requests_mock)
+    mock_post_to_action_scheduler(requests_mock)
+
+    response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
+        'trigger_date_time': '2019-05-08T09:00',
+        'action_type': 'ICL1E',
+        'where_clause': ' '
+    }, follow_redirects=True)
+
+    assert response.status_code == 400
+    assert b'Empty where clause' in response.data
+
+
+def mock_gets_from_action_scheduler(requests_mock):
+    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0', json=ACTION_PLAN)
+    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/actionRules', json=ACTION_RULES)
+
+
+def mock_post_to_action_scheduler(requests_mock):
+    requests_mock.post('/actionRules', json={})

--- a/tests/views/test_action_rules.py
+++ b/tests/views/test_action_rules.py
@@ -19,7 +19,7 @@ def test_create_action_rule(client, requests_mock):
     response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
         'trigger_date_time': '2019-05-08T09:00',
         'action_type': 'ICL1E',
-        'where_clause': "case_type != 'HI'"
+        'classifiers_clause': "case_type != 'HI'"
     }, follow_redirects=True)
 
     assert response.status_code == 200
@@ -32,11 +32,11 @@ def test_invalid_classifiers_responds_400(client, requests_mock):
     response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
         'trigger_date_time': '2019-05-08T09:00',
         'action_type': 'ICL1E',
-        'where_clause': "case_type != 'HI' AND "
+        'classifiers_clause': "case_type != 'HI' AND "
     }, follow_redirects=True)
 
     assert response.status_code == 400
-    assert b'Invalid where clause' in response.data
+    assert b'Invalid classifiers clause' in response.data
 
 
 def test_missing_classifiers_responds_400(client, requests_mock):
@@ -49,7 +49,7 @@ def test_missing_classifiers_responds_400(client, requests_mock):
     }, follow_redirects=True)
 
     assert response.status_code == 400
-    assert b'Empty where clause' in response.data
+    assert b'Empty classifiers clause' in response.data
 
 
 def test_empty_classifiers_responds_400(client, requests_mock):
@@ -59,11 +59,11 @@ def test_empty_classifiers_responds_400(client, requests_mock):
     response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
         'trigger_date_time': '2019-05-08T09:00',
         'action_type': 'ICL1E',
-        'where_clause': ' '
+        'classifiers_clause': ' '
     }, follow_redirects=True)
 
     assert response.status_code == 400
-    assert b'Empty where clause' in response.data
+    assert b'Empty classifiers clause' in response.data
 
 
 def mock_gets_from_action_scheduler(requests_mock):

--- a/tests/views/test_action_rules.py
+++ b/tests/views/test_action_rules.py
@@ -23,17 +23,3 @@ def test_create_action_rule(client, requests_mock):
     }, follow_redirects=True)
 
     assert response.status_code == 200
-
-
-def test_invalid_classifiers_json_responds_400(client, requests_mock):
-    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0', json=ACTION_PLAN)
-    requests_mock.get('/actionPlans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/actionRules', json=ACTION_RULES)
-    requests_mock.post('/actionRules', json={})
-    response = client.post('/action-plans/4c27fcbf-e069-44db-a239-99c9cd70a1d0/action-rules', data={
-        'trigger_date_time': '2019-05-08T09:00',
-        'action_type': 'ICL1E',
-        'classifiers': 'not valid json'
-    }, follow_redirects=True)
-
-    assert response.status_code == 400
-    assert b'Invalid classifiers json' in response.data


### PR DESCRIPTION
# Motivation and Context
Classifiers have become an SQL where clause that must now also contain the HI case filter.

# What has changed
* Change classifiers JSON text area to SQL string
* Validate where clause is not empty
* Improve docker file (more caching, less unnecessary installation)
* Improve action types drop down
* Update tests

# How to test?
Build and run locally with other ticket branches, check the action rules page still function correctly and the correct action rule gets created in the DB from the UI.

# Links
https://trello.com/c/TnldEmYZ/1023-address-frame-delta-generate-additional-initial-contact-files-13

# Screenshots (if appropriate):
![Default where clause example](https://user-images.githubusercontent.com/35268982/86452367-1b1b7000-bd14-11ea-878f-8f4097a0dc0d.png)
![Action types dropdown improvements](https://user-images.githubusercontent.com/35268982/86452384-2373ab00-bd14-11ea-8930-2638be6cad8d.png)
