### PR TITLE
feature/rabbitmq-guest-user

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,8 +26,8 @@ class K8SDevelopmentConfig(Config):
     RABBITMQ_VHOST = os.getenv('RABBITMQ_VHOST', '/')
     RABBITMQ_QUEUE = os.getenv('RABBITMQ_QUEUE', 'case.sample.inbound')
     RABBITMQ_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', '')
-    RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')
-    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'guest')
+    RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'rmquser')
+    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd')
     RABBITMQ_UNADDRESSED_QID_QUEUE = os.getenv('RABBITMQ_UNADDRESSED_QID_QUEUE', 'unaddressedRequestQueue')
 
 
@@ -41,8 +41,8 @@ class DevelopmentConfig(Config):
     RABBITMQ_VHOST = os.getenv('RABBITMQ_VHOST', '/')
     RABBITMQ_QUEUE = os.getenv('RABBITMQ_QUEUE', 'case.sample.inbound')
     RABBITMQ_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', '')
-    RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')
-    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'guest')
+    RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'rmquser')
+    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd')
     RABBITMQ_UNADDRESSED_QID_QUEUE = os.getenv('RABBITMQ_UNADDRESSED_QID_QUEUE', 'unaddressedRequestQueue')
 
 

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ class K8SDevelopmentConfig(Config):
     RABBITMQ_QUEUE = os.getenv('RABBITMQ_QUEUE', 'case.sample.inbound')
     RABBITMQ_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', '')
     RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'rmquser')
-    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd')
+    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'qpassword')
     RABBITMQ_UNADDRESSED_QID_QUEUE = os.getenv('RABBITMQ_UNADDRESSED_QID_QUEUE', 'unaddressedRequestQueue')
 
 
@@ -42,7 +42,7 @@ class DevelopmentConfig(Config):
     RABBITMQ_QUEUE = os.getenv('RABBITMQ_QUEUE', 'case.sample.inbound')
     RABBITMQ_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', '')
     RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'rmquser')
-    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'rmqp455w0rd')
+    RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'qpassword')
     RABBITMQ_UNADDRESSED_QID_QUEUE = os.getenv('RABBITMQ_UNADDRESSED_QID_QUEUE', 'unaddressedRequestQueue')
 
 


### PR DESCRIPTION
Security best practise urges us not to use default account usernames and passwords.

- **`rmquser`** - is the new standard rabbitmq user
- **`rmqmanager`** - is new metrics and monitoring user
- **`guest`** is to be deleted manually after release

Important : Do not forget when testing to give a BRANCH variable feature/rabbitmq-guest-user so that apply-kubernetes can download the correct tmp_rm_kube
